### PR TITLE
Added support for the "get" method

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "private": false,
   "peerDependencies": {
-    "@types/croppie": "^2.5.2",
+    "@types/croppie": "^2.5.3",
     "croppie": "^2.6.2"
   },
   "devDependencies": {
@@ -30,7 +30,7 @@
     "@angular/platform-browser": "^5.2.0",
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
-    "@types/croppie": "^2.5.2",
+    "@types/croppie": "^2.5.3",
     "@types/jasmine": "~2.8.3",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,3 +13,5 @@
   />
   <button type="button" class="btn btn-default" data-dismiss="modal" (click)="cancelCroppieEdit()">Cancel</button>
   <button type="button" class="btn btn-primary" (click)="saveImageFromCroppie()">Save</button>
+  <button type="button" class="btn btn-primary" (click)="getCropPoints()">Get crop points</button>
+</div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -81,5 +81,12 @@ export class AppComponent implements OnInit, OnChanges {
     };
     fr.readAsDataURL(file);
   }
+
+  getCropPoints() {
+    if (this.ngxCroppie) {
+      alert("Crop points: " + this.ngxCroppie.get().points);
+    }
+  }
+
 }
 

--- a/src/app/modules/ngx-croppie/ngx-croppie.component.ts
+++ b/src/app/modules/ngx-croppie/ngx-croppie.component.ts
@@ -1,13 +1,9 @@
 import { Component, OnInit, Input, EventEmitter, Output, ViewChild, ElementRef } from '@angular/core';
 
 import * as Croppie from 'croppie';
-import { CroppieOptions, ResultOptions } from 'croppie';
+import { CroppieOptions, ResultOptions, CropData } from 'croppie';
 
 export type Type = 'canvas' | 'base64' | 'html' | 'blob' | 'rawcanvas';
-
-export interface TempResultOptions extends ResultOptions {
-    type?: Type;
-}
 
 @Component({
     // tslint:disable-next-line:component-selector
@@ -19,10 +15,9 @@ export class NgxCroppieComponent implements OnInit {
     @Input() croppieOptions: CroppieOptions;
     @Input() imageUrl: string;
     @Input() bind: (img: string) => void;
-    @Input() outputFormatOptions: TempResultOptions = { type: 'base64', size: 'viewport' };
+    @Input() outputFormatOptions: ResultOptions = { type: 'base64', size: 'viewport' };
     @Output() result: EventEmitter<string | HTMLElement | Blob | HTMLCanvasElement>
                     = new EventEmitter<string | HTMLElement | Blob | HTMLCanvasElement>();
-
     private _croppie: Croppie;
     ngOnInit(): void {
         // https://github.com/Foliotek/Croppie/issues/470 :-( )
@@ -45,4 +40,9 @@ export class NgxCroppieComponent implements OnInit {
     rotate(degrees: 90 | 180 | 270 | -90 | -180 | -270) {
         this._croppie.rotate(degrees);
     }
+
+  get(): CropData {
+      return this._croppie.get();
+  }
+
 }


### PR DESCRIPTION
Hi,

Support for the "get" method from Croppie was recently added to the typings library (disclaimer: I was the one adding it). I have added support for it to ngx-croppie as well. This will enable user to read the crop points and zoom selected.

You can see a description of the method here: http://foliotek.github.io/Croppie/

I have also added a button to the demo application that uses this new method.

Regards
Knut Erik Helgesen